### PR TITLE
Make sure verify_signature always returns true/false tuple

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           otp-version: "25"
           elixir-version: "1.14"
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3.4.3
         name: Setup Elixir cache
         with:
           path: |
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-mix-otp-25-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-otp-25-
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3.4.3
         name: Setup Python cache
         with:
           path: ~/.cache/pip
@@ -40,7 +40,7 @@ jobs:
       # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
       # Cache key based on Elixir & Erlang version (also usefull when running in matrix)
       - name: Restore PLT cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.4.3
         id: plt_cache
         with:
           key: |
@@ -80,7 +80,7 @@ jobs:
         with:
           otp-version: "${{ matrix.otp-version }}"
           elixir-version: "${{ matrix.elixir-version }}"
-      - uses: actions/cache@v3.0.11
+      - uses: actions/cache@v3.4.3
         with:
           path: |
             deps

--- a/lib/openid_connect.ex
+++ b/lib/openid_connect.ex
@@ -258,7 +258,8 @@ defmodule OpenIDConnect do
       |> verify_signature(token_alg, jwt)
       |> case do
         {false, _claims, _jwt} -> false
-        verified_claims -> verified_claims
+        {true, claims, jwt} -> {true, claims, jwt}
+        _other -> false
       end
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpenIDConnect.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,7 @@ defmodule OpenIDConnect.Mixfile do
     [
       {:jason, ">= 1.0.0"},
       {:finch, "~> 0.14"},
-      {:jose, "~> 1.8"},
+      {:jose, "~> 1.11"},
 
       # Test deps
       {:earmark, "~> 1.2", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpenIDConnect.Mixfile do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.0.1"
 
   def project do
     [

--- a/test/fixtures/jwks/jwks_eddsa.exs
+++ b/test/fixtures/jwks/jwks_eddsa.exs
@@ -1,0 +1,37 @@
+%{
+  "keys" => [
+    %{
+      "kty" => "EC",
+      "kid" => "QKaRe_ok1wM_wbsCvCB7lRpOnxwLjInQiPOuRV92nC8",
+      "alg" => "ES256",
+      "crv" => "P-256",
+      "x" => "jCxZ0V54-DU69--IiH6B9eSLSCCjYjeZ_Be2H4x1ptU",
+      "y" => "3a1lEaXAQCXmhuUX4FQd-pcvLm0aIzF1GtUl_aEcsmE"
+    },
+    %{
+      "kty" => "OKP",
+      "kid" => "hGRpSjuI5dEvm1JeWD8j3HazXJORfEL6my5Xyv89qFg",
+      "alg" => "EdDSA",
+      "crv" => "Ed25519",
+      "x" => "8MoXvz-X_noeOdU-5x-j9-8eU9RaP4dLRpmHG9vvHdw"
+    },
+    %{
+      "kty" => "RSA",
+      "kid" => "zYb7k7iekVbatGuWqznHhnVaEOkdjJBy6HzxLJ2FRLo",
+      "use" => "sig",
+      "alg" => "RS256",
+      "n" =>
+        "oj7yfd1aiom5LuGtGpx8iDVfahf0FRHjPe6l2JTnLrb0E1UmW7g8PoapjuZ1ex50gJ0_kzbFBwkCsywhjYhvH7C_6rwWdKo08KvNP04ES1VPg3_9z92gTivH2dFBtYETpPYPb_stbzjaWKUVV2z4Gr5afU36Uqp9wGmZux6sbWHs3RUZr35m5Tm-eeVStf0ajqPAK9cyG8EzN1rB9s8mkGDpfVoGRAFSwb1AEGxuREkAR9cW0Emar8cOi4gH0JRIR35TgkkO7nGi1ZgXey99EgLWn1GTn1hY68L6vTOJg2MtDQlrOjYVDZIG41lN7OcL5kq96Vb5jBmpiDIK-pcL-w",
+      "e" => "AQAB"
+    },
+    %{
+      "alg" => "RS256",
+      "e" => "AQAB",
+      "kid" => "example@dockyard.com",
+      "kty" => "RSA",
+      "n" =>
+        "qlKll8no4lPYXNSuTTnacpFHiXwPOv_htCYvIXmiR7CWhiiOHQqj7KWXIW7TGxyoLVIyeRM4mwvkLI-UgsSMYdEKTT0j7Ydjrr0zCunPu5Gxr2yOmcRaszAzGxJL5DwpA0V40RqMlm5OuwdqS4To_p9LlLxzMF6RZe1OqslV5RZ4Y8FmrWq6BV98eIziEHL0IKdsAIrrOYkkcLDdQeMNuTp_yNB8Xl2TdWSdsbRomrs2dCtCqZcXTsy2EXDceHvYhgAB33nh_w17WLrZQwMM-7kJk36Kk54jZd7i80AJf_s_plXn1mEh-L5IAL1vg3a9EOMFUl-lPiGqc3td_ykH",
+      "use" => "sig"
+    }
+  ]
+}


### PR DESCRIPTION
Why:

* Due to an issue in the erlang-jose library (https://github.com/potatosalad/erlang-jose/issues/177) the verify_signature function would return a result of {:error, :function_clause} when trying to verify a signature using a JWKS where an EdDSA key was present in the key list prior to the key used to sign the JWT.

  Note: JWTs signed with EdDSA keys will work as expected.  This bug only occurred when the EdDSA key was present in the JWKS before the key used to sign the JWT.